### PR TITLE
Minor bug-fix to parentToObject and objectToParent

### DIFF
--- a/SimpleSceneGraph/include/nodes/Node.cpp
+++ b/SimpleSceneGraph/include/nodes/Node.cpp
@@ -509,14 +509,14 @@ vec2 Node2D::parentToScreen( const vec2 &pt ) const
 vec2 Node2D::parentToObject( const vec2 &pt ) const
 {
 	mat4 invTransform = glm::inverse( getTransform() );
-	vec4 p = invTransform * vec4( pt, 0, 0 );
+	vec4 p = invTransform * vec4( pt, 0, 1 );
 
 	return vec2( p.x, p.y );
 }
 
 vec2 Node2D::objectToParent( const vec2 &pt ) const
 {
-	vec4 p = getTransform() * vec4( pt, 0, 0 );
+	vec4 p = getTransform() * vec4( pt, 0, 1 );
 	return vec2( p.x, p.y );
 }
 


### PR DESCRIPTION
I've tested the 'parentToObject' code with a vec2( 0, 0 ) construct which isn't properly transformed into object space if the final coordinate is in the vec4 is zero.

Just out of instinct I think that the same 'fix' has to be applied to the objectToParent function but have not tested this at all.