### PR TITLE
docs: fix simple typo, qualilty -> quality

### DIFF
--- a/FXAA/assets/Fxaa3_11.h
+++ b/FXAA/assets/Fxaa3_11.h
@@ -1251,7 +1251,7 @@ Instead of using this on PC, I'd suggest just using FXAA Quality with
     #define FXAA_QUALITY__PRESET 10
 Or 
     #define FXAA_QUALITY__PRESET 20
-Either are higher qualilty and almost as fast as this on modern PC GPUs.
+Either are higher quality and almost as fast as this on modern PC GPUs.
 ============================================================================*/
 #if (FXAA_PC_CONSOLE == 1)
 /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
There is a small typo in FXAA/assets/Fxaa3_11.h.

Should read `quality` rather than `qualilty`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md